### PR TITLE
Remove JANKY_ environment variables

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = atom-editor
 	pkgdesc = Chrome-based text editor from Github
 	pkgver = 1.0.6
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/atom/atom
 	arch = x86_64
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,11 +3,11 @@
 # Upstream URL: https://github.com/atom/atom
 #
 # For improvements/fixes to this package, please send a pull request:
-# https://github.com/sjug/atom-editor 
+# https://github.com/sjug/atom-editor
 
 pkgname=atom-editor
 pkgver=1.0.6
-pkgrel=1
+pkgrel=2
 pkgdesc='Chrome-based text editor from Github'
 arch=('x86_64' 'i686')
 url='https://github.com/atom/atom'
@@ -19,9 +19,6 @@ source=("https://github.com/atom/atom/archive/v${pkgver}.tar.gz"
         'atom-python.patch')
 sha256sums=('4678c2893b7705ded697971aebc53c1b26b1a90ee172fd6c7232fb37990736aa'
             '9a1f4e2efa7c0b2fb053d27979b0231f75f1f0d928e06413ddebeadd5d7ed46c')
-
-_getref='f7a60c043bc05f38ac868e44a7191c76346e88a9'
-_gitbranch='master'
 
 prepare() {
   cd "atom-$pkgver"
@@ -41,8 +38,6 @@ build() {
   cd "$srcdir/atom-$pkgver"
 
   export PYTHON=python2
-  export JANKY_SHA1=$_gitref
-  export JANKY_BRANCH=$_gitbranch
   script/build --build-dir "$srcdir/atom-build"
 }
 


### PR DESCRIPTION
Have you ever wondered... 

Why does the build for this package succeed, despite the naming mismatch between variables `_getref` (on line 23) and `_gitref` (on line 44)?

That's right, it's because you don't need them! The [current Travis build for Atom on Linux](https://travis-ci.org/atom/atom/jobs/75183959#L109) doesn't use the `JANKY_` stuff, and neither should we. :smile:
